### PR TITLE
Change treetop handler API to use treetop.Response and return template data

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -113,9 +113,27 @@ All handler instances implement the `http.Handler` interface so you are free to 
 
 Each template file path is paired with a data handler. This function is responsible for yielding execution data for the corresponding template. For example,
 
-    func contactSubmitHandler(rsp treetop.Response, req *http.Request) {
-        // do stuff...
-        rsp.Data("Thanks friend!")
+
+    func contactSubmitHandler(_ treetop.Response, req *http.Request) interface{} {
+        // ...handle request here...
+        // data for template
+        return "Thanks friend!"
+    }
+
+Hierarchy works by chaining handlers together to assemble the various levels of template data into one data structure.
+
+    // parent view
+    func landingHandler(rsp treetop.Response, req *http.Request) interface{} {
+        return struct{
+            Content interface{}
+        }{
+            Content: rsp.HandlePartial("content", req),
+        }
+    }
+
+    // 'content' sub-view
+    func contactHandler(_ treetop.Response, _ *http.Request) interface{} {
+        return "...Contact form template data..."
     }
 
 The standard Go [html/template](https://golang.org/pkg/html/template/) library is used under the hood. However, a preferred engine can be configured without much fuss (once it supports inheritance).

--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ _TODO: Add more examples_
 
 ### Why was this created?
 
-Multi-page web applications are secure, well supported and promote loose coupling. They are a great solution for systems with a broad range of content or that encapsulate other complex systems. The main drawback versus native or single-page apps is interactivity. Modern software must deliver a modern user experience; linking documents together doesn't always cut it.
+Multi-page web applications are secure, well supported and promote loose coupling. They are a great solution for systems with a broad range of content or that encapsulate other complex systems. A major drawback versus native or single-page apps is interactivity. Modern software must deliver a modern user experience; linking documents together doesn't always cut it.
 
 Treetop is a prototype which aims to close the gap by extending conventional multi-page endpoints with 'partials' and 'fragments'. Treetop endpoints are capable of rendering a valid HTML document, or snippets for modifying a loaded page, depending upon which is requested.
 
@@ -113,9 +113,9 @@ All handler instances implement the `http.Handler` interface so you are free to 
 
 Each template file path is paired with a data handler. This function is responsible for yielding execution data for the corresponding template. For example,
 
-    func contactSubmitHandler(dw treetop.DataWriter, req *http.Request) {
+    func contactSubmitHandler(rsp treetop.Response, req *http.Request) {
         // do stuff...
-        dw.Data("Say Thanks!")
+        rsp.Data("Thanks friend!")
     }
 
 The standard Go [html/template](https://golang.org/pkg/html/template/) library is used under the hood. However, a preferred engine can be configured without much fuss (once it supports inheritance).

--- a/README.markdown
+++ b/README.markdown
@@ -120,10 +120,10 @@ Each template file path is paired with a data handler. This function is responsi
         return "Thanks friend!"
     }
 
-Hierarchy works by chaining handlers together to assemble the various levels of template data into one data structure.
+Hierarchy works by chaining handlers together to assemble tiers of template data into one data structure.
 
-    // parent view
-    func landingHandler(rsp treetop.Response, req *http.Request) interface{} {
+    // top-level handler delegates 'content' data loading to a sub handler
+    func baseHandler(rsp treetop.Response, req *http.Request) interface{} {
         return struct{
             Content interface{}
         }{
@@ -131,7 +131,7 @@ Hierarchy works by chaining handlers together to assemble the various levels of 
         }
     }
 
-    // 'content' sub-view
+    // sub-view which has the option to delegate further
     func contactHandler(_ treetop.Response, _ *http.Request) interface{} {
         return "...Contact form template data..."
     }

--- a/examples/greeter.go
+++ b/examples/greeter.go
@@ -56,15 +56,14 @@ func main() {
 	log.Fatal(http.ListenAndServe(":3000", nil))
 }
 
-func baseHandler(rsp treetop.Response, req *http.Request) {
-	msg, _ := rsp.Delegate("message", req)
-	rsp.Data(struct {
+func baseHandler(rsp treetop.Response, req *http.Request) interface{} {
+	return struct {
 		Message interface{}
 	}{
-		Message: msg,
-	})
+		Message: rsp.HandlePartial("message", req),
+	}
 }
 
-func greetingHandler(rsp treetop.Response, req *http.Request) {
-	rsp.Data(req.URL.Query().Get("name"))
+func greetingHandler(_ treetop.Response, req *http.Request) interface{} {
+	return req.URL.Query().Get("name")
 }

--- a/examples/greeter.go
+++ b/examples/greeter.go
@@ -56,15 +56,15 @@ func main() {
 	log.Fatal(http.ListenAndServe(":3000", nil))
 }
 
-func baseHandler(w treetop.DataWriter, req *http.Request) {
-	msg, _ := w.BlockData("message", req)
-	w.Data(struct {
+func baseHandler(rsp treetop.Response, req *http.Request) {
+	msg, _ := rsp.Delegate("message", req)
+	rsp.Data(struct {
 		Message interface{}
 	}{
 		Message: msg,
 	})
 }
 
-func greetingHandler(w treetop.DataWriter, req *http.Request) {
-	w.Data(req.URL.Query().Get("name"))
+func greetingHandler(rsp treetop.Response, req *http.Request) {
+	rsp.Data(req.URL.Query().Get("name"))
 }

--- a/handler.go
+++ b/handler.go
@@ -83,15 +83,15 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	if err := rsp.execute(&buf, h.Renderer, req); err != nil {
-		switch err {
-		case errRespWritten:
-			// a response has been written, abort treetop response
-			return
-		default:
-			log.Printf(err.Error())
-			http.Error(resp, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-			return
-		}
+		log.Printf(err.Error())
+		http.Error(resp, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	} else if rsp.finished {
+		// http response has already been resolved somehow, do not proceed
+		return
+	} else {
+		// mark response instance as finished
+		rsp.finished = true
 	}
 
 	resp.Header().Set("Content-Type", contentType)
@@ -100,23 +100,23 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		// Execute postscript templates for partial requests only
 		// each rendered template will be appended to the content body.
 		for index := 0; index < len(h.Postscript); index++ {
-			psDw := &responseImpl{
+			postRsp := &responseImpl{
 				ResponseWriter: resp,
 				context:        ctx,
 				responseId:     responseID,
 				partial:        &h.Postscript[index],
 			}
 
-			if err := psDw.execute(&buf, h.Renderer, req); err != nil {
-				switch err {
-				case errRespWritten:
-					// a response has been written, abort treetop response
-					return
-				default:
-					log.Printf(err.Error())
-					http.Error(resp, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-					return
-				}
+			if err := postRsp.execute(&buf, h.Renderer, req); err != nil {
+				log.Printf(err.Error())
+				http.Error(resp, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			} else if postRsp.finished {
+				// http response has already been resolved somehow, do not proceed
+				return
+			} else {
+				// mark response instance as finished
+				postRsp.finished = true
 			}
 		}
 

--- a/handler.go
+++ b/handler.go
@@ -15,7 +15,7 @@ var token uint32
 // Generate a token which can be used to identify treetop
 // responses *locally*. The only uniqueness requirement
 // is that concurrent active requests must not possess the same value.
-func nextResponseId() uint32 {
+func nextResponseID() uint32 {
 	return atomic.AddUint32(&token, 1)
 }
 
@@ -46,7 +46,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		return
 	default:
 	}
-	responseID := nextResponseId()
+	responseID := nextResponseID()
 	ctx, cancel := context.WithCancel(req.Context())
 	defer cancel() // Cancel treetop ctx when handler has done it's work.
 
@@ -78,7 +78,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	rsp := &responseImpl{
 		ResponseWriter: resp,
 		context:        ctx,
-		responseId:     responseID,
+		responseID:     responseID,
 		partial:        part,
 	}
 
@@ -103,7 +103,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 			postRsp := &responseImpl{
 				ResponseWriter: resp,
 				context:        ctx,
-				responseId:     responseID,
+				responseID:     responseID,
 				partial:        &h.Postscript[index],
 			}
 

--- a/handler.go
+++ b/handler.go
@@ -75,14 +75,14 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	// TODO: use buffer pool
 	var buf bytes.Buffer
 
-	dw := &dataWriter{
+	rsp := &responseImpl{
 		ResponseWriter: resp,
 		context:        ctx,
 		responseId:     responseID,
 		partial:        part,
 	}
 
-	if err := dw.execute(&buf, h.Renderer, req); err != nil {
+	if err := rsp.execute(&buf, h.Renderer, req); err != nil {
 		switch err {
 		case errRespWritten:
 			// a response has been written, abort treetop response
@@ -100,7 +100,7 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		// Execute postscript templates for partial requests only
 		// each rendered template will be appended to the content body.
 		for index := 0; index < len(h.Postscript); index++ {
-			psDw := &dataWriter{
+			psDw := &responseImpl{
 				ResponseWriter: resp,
 				context:        ctx,
 				responseId:     responseID,
@@ -130,8 +130,8 @@ func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	resp.Header().Set("Vary", "Accept")
 
 	// if a status code was specified, use it. Otherwise fallback to the net/http default.
-	if dw.status > 0 {
-		resp.WriteHeader(dw.status)
+	if rsp.status > 0 {
+		resp.WriteHeader(rsp.status)
 	}
 	buf.WriteTo(resp)
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -30,9 +30,9 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	cycle := Partial{
 		Extends:  "root",
 		Template: "test.templ.html",
-		HandlerFunc: func(rsp Response, req *http.Request) {
-			d, _ := rsp.Delegate("testblock", req)
-			rsp.Data(fmt.Sprintf("Loaded sub data: %s", d))
+		HandlerFunc: func(rsp Response, req *http.Request) interface{} {
+			d := rsp.HandlePartial("testblock", req)
+			return fmt.Sprintf("Loaded sub data: %s", d)
 		},
 		Blocks: []Partial{
 			{
@@ -86,9 +86,9 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			fields: fields{
 				Partial: &Partial{
 					Template: "test.templ.html",
-					HandlerFunc: func(rsp Response, req *http.Request) {
-						d, _ := rsp.Delegate("testblock", req)
-						rsp.Data(fmt.Sprintf("Loaded sub data: %s", d))
+					HandlerFunc: func(rsp Response, req *http.Request) interface{} {
+						d := rsp.HandlePartial("testblock", req)
+						return fmt.Sprintf("Loaded sub data: %s", d)
 					},
 					Blocks: []Partial{
 						{
@@ -241,14 +241,14 @@ func captureOutput(f func()) string {
 }
 
 func blockDebug(blocknames []string) HandlerFunc {
-	return func(rsp Response, req *http.Request) {
+	return func(rsp Response, req *http.Request) interface{} {
 		var d []struct {
 			Block string
 			Data  interface{}
 		}
 		for _, n := range blocknames {
-			data, ok := rsp.Delegate(n, req)
-			if ok {
+			data := rsp.HandlePartial(n, req)
+			if data != nil {
 				d = append(
 					d,
 					struct {
@@ -258,7 +258,7 @@ func blockDebug(blocknames []string) HandlerFunc {
 				)
 			}
 		}
-		rsp.Data(d)
+		return d
 	}
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -30,9 +30,9 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	cycle := Partial{
 		Extends:  "root",
 		Template: "test.templ.html",
-		HandlerFunc: func(dw DataWriter, req *http.Request) {
-			d, _ := dw.BlockData("testblock", req)
-			dw.Data(fmt.Sprintf("Loaded sub data: %s", d))
+		HandlerFunc: func(rsp Response, req *http.Request) {
+			d, _ := rsp.Delegate("testblock", req)
+			rsp.Data(fmt.Sprintf("Loaded sub data: %s", d))
 		},
 		Blocks: []Partial{
 			{
@@ -86,9 +86,9 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			fields: fields{
 				Partial: &Partial{
 					Template: "test.templ.html",
-					HandlerFunc: func(dw DataWriter, req *http.Request) {
-						d, _ := dw.BlockData("testblock", req)
-						dw.Data(fmt.Sprintf("Loaded sub data: %s", d))
+					HandlerFunc: func(rsp Response, req *http.Request) {
+						d, _ := rsp.Delegate("testblock", req)
+						rsp.Data(fmt.Sprintf("Loaded sub data: %s", d))
 					},
 					Blocks: []Partial{
 						{
@@ -241,13 +241,13 @@ func captureOutput(f func()) string {
 }
 
 func blockDebug(blocknames []string) HandlerFunc {
-	return func(dw DataWriter, req *http.Request) {
+	return func(rsp Response, req *http.Request) {
 		var d []struct {
 			Block string
 			Data  interface{}
 		}
 		for _, n := range blocknames {
-			data, ok := dw.BlockData(n, req)
+			data, ok := rsp.Delegate(n, req)
 			if ok {
 				d = append(
 					d,
@@ -258,7 +258,7 @@ func blockDebug(blocknames []string) HandlerFunc {
 				)
 			}
 		}
-		dw.Data(d)
+		rsp.Data(d)
 	}
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -5,26 +5,26 @@ import (
 	"strings"
 )
 
-func Noop(_ DataWriter, _ *http.Request) {}
+func Noop(_ Response, _ *http.Request) {}
 
 func Constant(data interface{}) HandlerFunc {
-	return func(dw DataWriter, _ *http.Request) {
-		dw.Data(data)
+	return func(rsp Response, _ *http.Request) {
+		rsp.Data(data)
 	}
 }
 
 func Delegate(blockname string) HandlerFunc {
-	return func(dw DataWriter, req *http.Request) {
-		data, ok := dw.BlockData(blockname, req)
+	return func(rsp Response, req *http.Request) {
+		data, ok := rsp.Delegate(blockname, req)
 		if ok {
-			dw.Data(data)
+			rsp.Data(data)
 		}
 	}
 }
 
 func RequestHandler(f func(*http.Request) interface{}) HandlerFunc {
-	return func(dw DataWriter, req *http.Request) {
-		dw.Data(f(req))
+	return func(rsp Response, req *http.Request) {
+		rsp.Data(f(req))
 	}
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -5,26 +5,23 @@ import (
 	"strings"
 )
 
-func Noop(_ Response, _ *http.Request) {}
+func Noop(_ Response, _ *http.Request) interface{} { return nil }
 
 func Constant(data interface{}) HandlerFunc {
-	return func(rsp Response, _ *http.Request) {
-		rsp.Data(data)
+	return func(rsp Response, _ *http.Request) interface{} {
+		return data
 	}
 }
 
 func Delegate(blockname string) HandlerFunc {
-	return func(rsp Response, req *http.Request) {
-		data, ok := rsp.Delegate(blockname, req)
-		if ok {
-			rsp.Data(data)
-		}
+	return func(rsp Response, req *http.Request) interface{} {
+		return rsp.HandlePartial(blockname, req)
 	}
 }
 
 func RequestHandler(f func(*http.Request) interface{}) HandlerFunc {
-	return func(rsp Response, req *http.Request) {
-		rsp.Data(f(req))
+	return func(_ Response, req *http.Request) interface{} {
+		return f(req)
 	}
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -11,7 +11,7 @@ type Response interface {
 	Status(int) int
 	Done() bool
 	HandlePartial(string, *http.Request) interface{}
-	ResponseId() uint32
+	ResponseID() uint32
 	Context() context.Context
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -6,17 +6,18 @@ import (
 	"net/http"
 )
 
-type DataWriter interface {
+type Response interface {
 	http.ResponseWriter
 	Data(interface{})
 	Status(int)
-	BlockData(string, *http.Request) (interface{}, bool)
+	Delegate(string, *http.Request) (interface{}, bool)
+	DelegateWithDefault(string, *http.Request, interface{}) interface{}
 	ResponseId() uint32
 	Context() context.Context
 }
 
 type TemplateExec func(io.Writer, []string, interface{}) error
-type HandlerFunc func(DataWriter, *http.Request)
+type HandlerFunc func(Response, *http.Request)
 
 type View interface {
 	SubView(string, string, HandlerFunc) View

--- a/interfaces.go
+++ b/interfaces.go
@@ -8,16 +8,15 @@ import (
 
 type Response interface {
 	http.ResponseWriter
-	Data(interface{})
-	Status(int)
-	Delegate(string, *http.Request) (interface{}, bool)
-	DelegateWithDefault(string, *http.Request, interface{}) interface{}
+	Status(int) int
+	Done() bool
+	HandlePartial(string, *http.Request) interface{}
 	ResponseId() uint32
 	Context() context.Context
 }
 
 type TemplateExec func(io.Writer, []string, interface{}) error
-type HandlerFunc func(Response, *http.Request)
+type HandlerFunc func(Response, *http.Request) interface{}
 
 type View interface {
 	SubView(string, string, HandlerFunc) View

--- a/redirect.go
+++ b/redirect.go
@@ -57,6 +57,14 @@ func SeeOtherPage(w http.ResponseWriter, req *http.Request, location string) boo
 	return true
 }
 
+// Helper that will do a treetop 'SeeOtherPage' redirect if the request is for a partial
+// or fall back to a standard HTTP redirect otherwise using the status code supplied.
+func Redirect(w http.ResponseWriter, req *http.Request, location string, status int) {
+	if ok := SeeOtherPage(w, req, location); !ok {
+		http.Redirect(w, req, location, status)
+	}
+}
+
 // Lifted from golang codebase,
 // see issue https://go-review.googlesource.com/c/go/+/31732
 func hexEscapeNonASCII(s string) string {

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -50,3 +50,63 @@ func TestSeeOtherPage(t *testing.T) {
 		})
 	}
 }
+
+func TestRedirect(t *testing.T) {
+	type args struct {
+		w        *httptest.ResponseRecorder
+		req      *http.Request
+		location string
+		status   int
+	}
+	req := httptest.NewRequest("GET", "/some/path", nil)
+	req.Header.Set("Accept", FragmentContentType)
+	tests := []struct {
+		name         string
+		args         args
+		ttWant       string
+		locationWant string
+		status       int
+	}{
+		{
+			name: "basic",
+			args: args{
+				w:        httptest.NewRecorder(),
+				req:      req,
+				location: "test/",
+				status:   http.StatusSeeOther,
+			},
+			ttWant:       "/some/test/",
+			locationWant: "",
+			status:       http.StatusNoContent,
+		},
+		{
+			name: "non-treetop request",
+			args: args{
+				w:        httptest.NewRecorder(),
+				req:      httptest.NewRequest("GET", "/some/path", nil),
+				location: "test/",
+				status:   http.StatusFound,
+			},
+			ttWant:       "",
+			locationWant: "/some/test/",
+			status:       http.StatusFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Redirect(tt.args.w, tt.args.req, tt.args.location, tt.args.status)
+			ttGot := tt.args.w.Result().Header.Get("X-Treetop-See-Other")
+			if ttGot != tt.ttWant {
+				t.Errorf("SeeOtherPage() = %v, want %v", ttGot, tt.ttWant)
+			}
+			locGot := tt.args.w.Result().Header.Get("Location")
+			if locGot != tt.locationWant {
+				t.Errorf("http.Redirect() = %v, want %v", locGot, tt.locationWant)
+			}
+			status := tt.args.w.Result().StatusCode
+			if status != tt.status {
+				t.Errorf("http.Redirect() = %v, want %v", status, tt.status)
+			}
+		})
+	}
+}

--- a/response.go
+++ b/response.go
@@ -8,7 +8,7 @@ import (
 
 type responseImpl struct {
 	http.ResponseWriter
-	responseId uint32
+	responseID uint32
 	context    context.Context
 	finished   bool
 	status     int
@@ -75,7 +75,7 @@ func (rsp *responseImpl) HandlePartial(name string, req *http.Request) interface
 	// 3. construct a sub responseImpl
 	subResp := responseImpl{
 		ResponseWriter: rsp.ResponseWriter,
-		responseId:     rsp.responseId,
+		responseID:     rsp.responseID,
 		context:        rsp.context,
 		partial:        part,
 	}
@@ -100,8 +100,8 @@ func (rsp *responseImpl) Context() context.Context {
 
 // Locally unique ID for Treetop HTTP response. This is intended to be used to keep track of
 // the request as is passes between handlers.
-func (rsp *responseImpl) ResponseId() uint32 {
-	return rsp.responseId
+func (rsp *responseImpl) ResponseID() uint32 {
+	return rsp.responseID
 }
 
 // Load data from handlers hierarchy and execute template. Body will be written to IO writer passed in.

--- a/response_test.go
+++ b/response_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func Test_responseImpl_Delegate(t *testing.T) {
+func Test_responseImpl_PartialHandler(t *testing.T) {
 	type fields struct {
 		http.ResponseWriter
 		responseId      uint32
@@ -28,7 +28,6 @@ func Test_responseImpl_Delegate(t *testing.T) {
 		fields fields
 		args   args
 		data   interface{}
-		flag   bool
 		status int
 	}{
 		{
@@ -43,7 +42,6 @@ func Test_responseImpl_Delegate(t *testing.T) {
 				req:  req,
 			},
 			data: nil,
-			flag: false,
 		},
 		{
 			name: "Simple data",
@@ -64,7 +62,6 @@ func Test_responseImpl_Delegate(t *testing.T) {
 				req:  req,
 			},
 			data: "This is a test",
-			flag: true,
 		},
 		{
 			name: "Adopt sub-handler HTTP status",
@@ -76,9 +73,9 @@ func Test_responseImpl_Delegate(t *testing.T) {
 					Blocks: []Partial{
 						Partial{
 							Extends: "some-block",
-							HandlerFunc: func(rsp Response, _ *http.Request) {
+							HandlerFunc: func(rsp Response, _ *http.Request) interface{} {
 								rsp.Status(501)
-								rsp.Data("Not Implemented")
+								return "Not Implemented"
 							},
 						},
 					},
@@ -89,7 +86,6 @@ func Test_responseImpl_Delegate(t *testing.T) {
 				req:  req,
 			},
 			data:   "Not Implemented",
-			flag:   true,
 			status: 501,
 		},
 		{
@@ -101,8 +97,8 @@ func Test_responseImpl_Delegate(t *testing.T) {
 					Blocks: []Partial{
 						Partial{
 							Extends: "some-block",
-							HandlerFunc: func(rsp Response, _ *http.Request) {
-								rsp.Data(fmt.Sprintf("Response token %v", rsp.ResponseId()))
+							HandlerFunc: func(rsp Response, _ *http.Request) interface{} {
+								return fmt.Sprintf("Response token %v", rsp.ResponseId())
 							},
 						},
 					},
@@ -113,7 +109,6 @@ func Test_responseImpl_Delegate(t *testing.T) {
 				req:  req,
 			},
 			data: "Response token 1234",
-			flag: true,
 		},
 		{
 			name: "Block not found",
@@ -134,26 +129,20 @@ func Test_responseImpl_Delegate(t *testing.T) {
 				req:  req,
 			},
 			data: nil,
-			flag: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rsp := &responseImpl{
-				ResponseWriter:  tt.fields.ResponseWriter,
-				responseId:      tt.fields.responseId,
-				responseWritten: tt.fields.responseWritten,
-				dataCalled:      tt.fields.dataCalled,
-				data:            tt.fields.data,
-				status:          tt.fields.status,
-				partial:         &tt.fields.partial,
+				ResponseWriter: tt.fields.ResponseWriter,
+				responseId:     tt.fields.responseId,
+				finished:       tt.fields.responseWritten,
+				status:         tt.fields.status,
+				partial:        &tt.fields.partial,
 			}
-			got, got1 := rsp.Delegate(tt.args.name, tt.args.req)
+			got := rsp.HandlePartial(tt.args.name, tt.args.req)
 			if !reflect.DeepEqual(got, tt.data) {
-				t.Errorf("responseImpl.Delegate() got = %v, want %v", got, tt.data)
-			}
-			if got1 != tt.flag {
-				t.Errorf("responseImpl.Delegate() flag = %v, want %v", got1, tt.flag)
+				t.Errorf("responseImpl.PartialHandler() got = %v, want %v", got, tt.data)
 			}
 			if rsp.status != tt.status {
 				t.Errorf("responseImpl.status = %v, want %v", rsp.status, tt.status)

--- a/response_test.go
+++ b/response_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func Test_dataWriter_BlockData(t *testing.T) {
+func Test_responseImpl_Delegate(t *testing.T) {
 	type fields struct {
 		http.ResponseWriter
 		responseId      uint32
@@ -76,9 +76,9 @@ func Test_dataWriter_BlockData(t *testing.T) {
 					Blocks: []Partial{
 						Partial{
 							Extends: "some-block",
-							HandlerFunc: func(dw DataWriter, _ *http.Request) {
-								dw.Status(501)
-								dw.Data("Not Implemented")
+							HandlerFunc: func(rsp Response, _ *http.Request) {
+								rsp.Status(501)
+								rsp.Data("Not Implemented")
 							},
 						},
 					},
@@ -101,8 +101,8 @@ func Test_dataWriter_BlockData(t *testing.T) {
 					Blocks: []Partial{
 						Partial{
 							Extends: "some-block",
-							HandlerFunc: func(dw DataWriter, _ *http.Request) {
-								dw.Data(fmt.Sprintf("Response token %v", dw.ResponseId()))
+							HandlerFunc: func(rsp Response, _ *http.Request) {
+								rsp.Data(fmt.Sprintf("Response token %v", rsp.ResponseId()))
 							},
 						},
 					},
@@ -139,7 +139,7 @@ func Test_dataWriter_BlockData(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dw := &dataWriter{
+			rsp := &responseImpl{
 				ResponseWriter:  tt.fields.ResponseWriter,
 				responseId:      tt.fields.responseId,
 				responseWritten: tt.fields.responseWritten,
@@ -148,15 +148,15 @@ func Test_dataWriter_BlockData(t *testing.T) {
 				status:          tt.fields.status,
 				partial:         &tt.fields.partial,
 			}
-			got, got1 := dw.BlockData(tt.args.name, tt.args.req)
+			got, got1 := rsp.Delegate(tt.args.name, tt.args.req)
 			if !reflect.DeepEqual(got, tt.data) {
-				t.Errorf("dataWriter.BlockData() got = %v, want %v", got, tt.data)
+				t.Errorf("responseImpl.Delegate() got = %v, want %v", got, tt.data)
 			}
 			if got1 != tt.flag {
-				t.Errorf("dataWriter.BlockData() flag = %v, want %v", got1, tt.flag)
+				t.Errorf("responseImpl.Delegate() flag = %v, want %v", got1, tt.flag)
 			}
-			if dw.status != tt.status {
-				t.Errorf("dataWriter.status = %v, want %v", dw.status, tt.status)
+			if rsp.status != tt.status {
+				t.Errorf("responseImpl.status = %v, want %v", rsp.status, tt.status)
 			}
 		})
 	}

--- a/response_test.go
+++ b/response_test.go
@@ -11,7 +11,7 @@ import (
 func Test_responseImpl_PartialHandler(t *testing.T) {
 	type fields struct {
 		http.ResponseWriter
-		responseId      uint32
+		responseID      uint32
 		responseWritten bool
 		dataCalled      bool
 		data            interface{}
@@ -34,7 +34,7 @@ func Test_responseImpl_PartialHandler(t *testing.T) {
 			name: "Nil case",
 			fields: fields{
 				ResponseWriter: &httptest.ResponseRecorder{},
-				responseId:     1234,
+				responseID:     1234,
 				partial:        Partial{},
 			},
 			args: args{
@@ -47,7 +47,7 @@ func Test_responseImpl_PartialHandler(t *testing.T) {
 			name: "Simple data",
 			fields: fields{
 				ResponseWriter: &httptest.ResponseRecorder{},
-				responseId:     1234,
+				responseID:     1234,
 				partial: Partial{
 					Blocks: []Partial{
 						Partial{
@@ -67,7 +67,7 @@ func Test_responseImpl_PartialHandler(t *testing.T) {
 			name: "Adopt sub-handler HTTP status",
 			fields: fields{
 				ResponseWriter: &httptest.ResponseRecorder{},
-				responseId:     1234,
+				responseID:     1234,
 				status:         400,
 				partial: Partial{
 					Blocks: []Partial{
@@ -89,16 +89,16 @@ func Test_responseImpl_PartialHandler(t *testing.T) {
 			status: 501,
 		},
 		{
-			name: "ResponseId passed down",
+			name: "ResponseID passed down",
 			fields: fields{
 				ResponseWriter: &httptest.ResponseRecorder{},
-				responseId:     1234,
+				responseID:     1234,
 				partial: Partial{
 					Blocks: []Partial{
 						Partial{
 							Extends: "some-block",
 							HandlerFunc: func(rsp Response, _ *http.Request) interface{} {
-								return fmt.Sprintf("Response token %v", rsp.ResponseId())
+								return fmt.Sprintf("Response token %v", rsp.ResponseID())
 							},
 						},
 					},
@@ -114,7 +114,7 @@ func Test_responseImpl_PartialHandler(t *testing.T) {
 			name: "Block not found",
 			fields: fields{
 				ResponseWriter: &httptest.ResponseRecorder{},
-				responseId:     1234,
+				responseID:     1234,
 				partial: Partial{
 					Blocks: []Partial{
 						Partial{
@@ -135,7 +135,7 @@ func Test_responseImpl_PartialHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rsp := &responseImpl{
 				ResponseWriter: tt.fields.ResponseWriter,
-				responseId:     tt.fields.responseId,
+				responseID:     tt.fields.responseID,
 				finished:       tt.fields.responseWritten,
 				status:         tt.fields.status,
 				partial:        &tt.fields.partial,


### PR DESCRIPTION
API changes to `treetop.HandlerFunc` signature following experimentation and feedback from other developers.

### `... *http.Request) interface{}` return type
The only reason for `dw.Data(..)` in the old API was to avoid including a return type in each handler signature. This is not a good reason, especially since it hides that data is being yielded. Feedback from developers was that `interface{}` return type makes the mechanism more obvious. In my view, it is an important detail of what the function does so it should be part of the type signature. 

### `treetop.DataWriter` interface changed to `treetop.Response`
Since this interface is not related to the Golang IO pattern, the term 'Writer' should not be used. Also, since the instance no longer receives handler data directly, its role has been narrowed. 'Response' API  seems like an appropriate choice.