### PR TITLE
Change view handler creation API

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -103,9 +103,9 @@ The Treetop library includes an abstraction for creating more complex networks o
         contactSubmitHandler,
     )
 
-    mux.Handler("/", landing.PartialHandler())
-    mux.Handler("/contact", contactForm.PartialHandler())
-    mux.Handler("/contact/submit", submit.FragmentHandler())
+    mux.Handler("/", treetop.ViewHandler(landing))
+    mux.Handler("/contact", treetop.ViewHandler(contactForm))
+    mux.Handler("/contact/submit", treetop.ViewHandler(submit).FragmentOnly())
 
 All handler instances implement the `http.Handler` interface so you are free to use whatever routing library you wish.
 

--- a/examples/greeter.go
+++ b/examples/greeter.go
@@ -50,8 +50,8 @@ func main() {
 	greetForm := page.SubView("message", landing, treetop.Noop)
 	greetMessage := page.SubView("message", greeting, greetingHandler)
 
-	http.Handle("/", greetForm.PartialHandler())
-	http.Handle("/greet", greetMessage.PartialHandler())
+	http.Handle("/", treetop.ViewHandler(greetForm))
+	http.Handle("/greet", treetop.ViewHandler(greetMessage))
 	fmt.Println("serving on http://0.0.0.0:3000/")
 	log.Fatal(http.ListenAndServe(":3000", nil))
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Response is the HandlerFunc facade for the treetop request response process.
-// It can be used to delegate handling to block and to track the resolutation of a
+// It can be used to delegate handling to block and to track the resolution of a
 // single request across multiple handlers.
 type Response interface {
 	http.ResponseWriter
@@ -18,7 +18,7 @@ type Response interface {
 	Context() context.Context
 }
 
-// TemplateExec interface is a signiture of a function which can be configured to
+// TemplateExec interface is a signature of a function which can be configured to
 // execute the templates with supplied data.
 type TemplateExec func(io.Writer, []string, interface{}) error
 
@@ -26,12 +26,10 @@ type TemplateExec func(io.Writer, []string, interface{}) error
 // partial data loading.
 type HandlerFunc func(Response, *http.Request) interface{}
 
-// View is an inteface for a hierarchical view configuartion. Named child views can be
+// View is an interface for a hierarchical view configuration. Named child views can be
 // added and a http.Handler instance can be derived.
 type View interface {
 	SubView(string, string, HandlerFunc) View
 	DefaultSubView(string, string, HandlerFunc) View
-	PageHandler() *Handler
-	PartialHandler() *Handler
-	FragmentHandler() *Handler
+	Handler() *Handler
 }

--- a/printer.go
+++ b/printer.go
@@ -10,20 +10,20 @@ import (
 
 func PrintHandler(h *Handler) string {
 	var handlerInfo string
-	if h.Partial.HandlerFunc != nil {
-		handlerInfo = runtime.FuncForPC(reflect.ValueOf(h.Partial.HandlerFunc).Pointer()).Name()
+	if h.Fragment.HandlerFunc != nil {
+		handlerInfo = runtime.FuncForPC(reflect.ValueOf(h.Fragment.HandlerFunc).Pointer()).Name()
 	} else {
 		handlerInfo = "nil"
 	}
 	if h.Page == nil {
 		// only fragment requests can be handled
-		return fmt.Sprintf("FragmentHandler(%s, %s)", previewTemplate(h.Partial.Template, 10, 10), handlerInfo)
-	} else if h.Partial == nil {
+		return fmt.Sprintf("FragmentHandler(%s, %s)", previewTemplate(h.Fragment.Template, 10, 10), handlerInfo)
+	} else if h.Fragment == nil {
 		// only full page requests can be handled
-		return fmt.Sprintf("PageHandler(%s, %s)", previewTemplate(h.Partial.Template, 10, 10), handlerInfo)
+		return fmt.Sprintf("PageHandler(%s, %s)", previewTemplate(h.Fragment.Template, 10, 10), handlerInfo)
 	} else {
 		// both full page and partial page requests can be handled
-		return fmt.Sprintf("PartialHandler(%s, %s)", previewTemplate(h.Partial.Template, 10, 10), handlerInfo)
+		return fmt.Sprintf("PartialHandler(%s, %s)", previewTemplate(h.Fragment.Template, 10, 10), handlerInfo)
 	}
 }
 

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -13,11 +13,11 @@ func Test_renderer_new_page(t *testing.T) {
 	page.DefaultSubView("A", "a.templ.html", Noop)
 	def := page.SubView("B", "b.templ.html", Noop)
 
-	handler := def.PartialHandler()
+	handler := def.Handler()
 
 	expects := []string{"b.templ.html"}
-	if files, err := handler.Partial.TemplateList(); err != nil {
-		t.Errorf("treetop.Define() Partial = unexpected error %s", err.Error())
+	if files, err := handler.Fragment.TemplateList(); err != nil {
+		t.Errorf("treetop.Define() Fragment = unexpected error %s", err.Error())
 	} else if !reflect.DeepEqual(files, expects) {
 		t.Errorf("treetop.Define() = %v, want %v", files, expects)
 	}

--- a/view.go
+++ b/view.go
@@ -60,7 +60,7 @@ func (t *viewImpl) DefaultSubView(blockName, template string, handler HandlerFun
 	return sub
 }
 
-func (t *viewImpl) PageHandler() *Handler {
+func (t *viewImpl) Handler() *Handler {
 	part := t.derivePartial(nil)
 	page := part
 	root := t
@@ -69,35 +69,12 @@ func (t *viewImpl) PageHandler() *Handler {
 		page = root.derivePartial(page)
 	}
 	handler := Handler{
+		Fragment: part,
 		Page:     page,
 		Renderer: t.renderer,
 	}
 
 	return &handler
-}
-
-func (t *viewImpl) PartialHandler() *Handler {
-	part := t.derivePartial(nil)
-	page := part
-	root := t
-	for root.extends != nil && root.extends.parent != nil {
-		root = root.extends.parent
-		page = root.derivePartial(page)
-	}
-	handler := Handler{
-		Partial:  part,
-		Page:     page,
-		Renderer: t.renderer,
-	}
-
-	return &handler
-}
-
-func (t *viewImpl) FragmentHandler() *Handler {
-	return &Handler{
-		Partial:  t.derivePartial(nil),
-		Renderer: t.renderer,
-	}
 }
 
 func (t *viewImpl) derivePartial(override *Partial) *Partial {

--- a/view_test.go
+++ b/view_test.go
@@ -56,7 +56,7 @@ func Test_extend_block_basic(t *testing.T) {
 	part := basePartial()
 	p := part.SubView("test", "test.templ.html", Noop)
 
-	got := PrintHandler(p.FragmentHandler())
+	got := PrintHandler(p.Handler().FragmentOnly())
 	expecting := `FragmentHandler("test.templ.html", github.com/rur/treetop.Noop)`
 	if !strings.Contains(got, expecting) {
 		t.Errorf("Extended template, expecting: %s, got %s", expecting, got)
@@ -68,7 +68,7 @@ func Test_fragment_with_blocks(t *testing.T) {
 	p := part.SubView("test", "test.templ.html", Noop)
 	p.DefaultSubView("sub", "sub.templ.html", Noop)
 
-	got, err := p.FragmentHandler().Partial.TemplateList()
+	got, err := p.Handler().FragmentOnly().Fragment.TemplateList()
 	if err != nil {
 		t.Errorf("Unexpected error while aggregating templates: %s", err.Error())
 	}
@@ -82,7 +82,7 @@ func Test_extend_block_partial(t *testing.T) {
 	part := basePartial()
 	p := part.SubView("test", "test.templ.html", Noop)
 
-	handler := p.PartialHandler()
+	handler := p.Handler()
 	expecting := `PartialHandler("test.templ.html", github.com/rur/treetop.Noop)`
 	got := PrintHandler(handler)
 
@@ -110,11 +110,11 @@ func Test_extend_multiple_levels(t *testing.T) {
 
 	test2_b.DefaultSubView("B_plus", "test2_B_plus.templ.html", Noop)
 
-	handler := test2_b.PartialHandler()
+	handler := test2_b.Handler()
 
 	var expectingTempl []string
 	expectingTempl = []string{"test2_B.templ.html", "test2_B_plus.templ.html"}
-	if templates, err := handler.Partial.TemplateList(); err != nil {
+	if templates, err := handler.Fragment.TemplateList(); err != nil {
 		t.Errorf("Failed to load partial template, error: %s", err.Error())
 	} else if !reflect.DeepEqual(templates, expectingTempl) {
 		t.Errorf("Failed to list templates from partial, expecting: %s got %s", expectingTempl, templates)


### PR DESCRIPTION
Remove `PartialHandler`, `FragmentHandler` and `PageHandler` they were confusing. 

The most important change is that the `.Include` method on handler instances was removed. Now a **Handler** instance can only be created from **View** instances. There is no way to 'extend' an existing handler. 