### PR TITLE
[0.4.1] Vary header fix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,7 +12,7 @@ blocks:
       jobs:
         - name: go test
           commands:
-            - sem-version go 1.13
+            - sem-version go 1.16
             - "export GO111MODULE=on"
             - "export GOPATH=~/go"
             - "export PATH=/home/semaphore/go/bin:$PATH"
@@ -23,7 +23,7 @@ blocks:
 
         - name: Coveralls
           commands:
-            - sem-version go 1.13
+            - sem-version go 1.16
             - "export GO111MODULE=on"
             - "export GOPATH=~/go"
             - "export PATH=/home/semaphore/go/bin:$PATH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ user defined headers.
 
 - Do not clobber user defined _Vary_ header values when responding from a dual fragment/page endpoint
 
+### Changes
+
+- CI now runs tests against a newer version of golang (1.16)
+
 ## [0.4.0] - 2021-08-08
 
 Finalize release candidate for v0.4 and embedded client code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.4.1] - 2021-10-02
+
+Fix issue with the assignment of the Vary header and improve test coverage for
+user defined headers.
+
+### Bugfix
+
+- Do not clobber user defined _Vary_ header values when responding from a dual fragment/page endpoint
+
 ## [0.4.0] - 2021-08-08
 
 Finalize release candidate for v0.4 and embedded client code

--- a/handler.go
+++ b/handler.go
@@ -191,7 +191,7 @@ func (h *TemplateHandler) servePageRequest(resp *ResponseWrapper, req *http.Requ
 
 	if h.Partial != nil {
 		// inform cache that another content type is possible for this endpoint
-		resp.Header().Set("Vary", "Accept")
+		resp.Header().Add("Vary", "Accept")
 	}
 
 	// set content type as standard html mimetype

--- a/handler_test.go
+++ b/handler_test.go
@@ -49,6 +49,7 @@ func setupTemplateHandler() ViewHandler {
 	})
 	base.NewDefaultSubView("nav", "nav.html", Noop)
 	content := base.NewSubView("content", "content.html", func(resp Response, req *http.Request) interface{} {
+		resp.Header().Add("Vary", "Cookie")
 		return struct {
 			Message    string
 			SubContent interface{}
@@ -92,6 +93,12 @@ func TestTemplateHandler_PartialRequest(t *testing.T) {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(rec.Body)
 
+	gotVary := strings.Join(rec.Header().Values("Vary"), ", ")
+	expectVary := "Cookie, Accept"
+	if gotVary != expectVary {
+		t.Errorf("Expecting Vary header: [%s], got: [%s]", expectVary, gotVary)
+	}
+
 	if body := buf.String(); body != expecting {
 		t.Errorf("Expecting body \n%s\nGOT\n%s", expecting, body)
 	}
@@ -121,8 +128,7 @@ func TestTemplateHandler_PageRequestNotAcceptable(t *testing.T) {
 }
 
 func TestTemplateHandler_PageRequest(t *testing.T) {
-	th := setupTemplateHandler()
-	handler := th.PageOnly()
+	handler := setupTemplateHandler().PageOnly()
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, mockRequest("/some/path", "*/*"))
 
@@ -155,6 +161,12 @@ func TestTemplateHandler_PageRequest(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(rec.Body)
+
+	gotVary := strings.Join(rec.Header().Values("Vary"), ", ")
+	expectVary := "Cookie"
+	if gotVary != expectVary {
+		t.Errorf("Expecting Vary header: [%s], got: [%s]", expectVary, gotVary)
+	}
 
 	if body := buf.String(); body != expecting {
 		t.Errorf("Expecting body \n%s\ngot\n%s", expecting, body)

--- a/handler_test.go
+++ b/handler_test.go
@@ -200,3 +200,20 @@ func TestTemplateHandler_DesignatePageURL(t *testing.T) {
 		t.Errorf("Expecting X-Page-URL header to be %s, got %s", expecting, pageURL)
 	}
 }
+
+func TestTemplateHandler_AdditionalVaryHeaders(t *testing.T) {
+	exec := NewKeyedStringExecutor(handlerTemplateTestTemplateMap)
+	v := NewSubView("sub-content", "sub-content.html", func(resp Response, req *http.Request) interface{} {
+		resp.Header().Add("Vary", "Cookie")
+		return "testing"
+	})
+
+	th := exec.NewViewHandler(v)
+	rec := httptest.NewRecorder()
+	th.ServeHTTP(rec, mockRequest("/some/path", TemplateContentType))
+	expecting := "Cookie, Accept"
+	varyHeader := rec.Header().Values("Vary")
+	if strings.Join(varyHeader, ", ") != expecting {
+		t.Errorf("Expecting Vary header to be [%s], got %v", expecting, varyHeader)
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -76,7 +76,7 @@ func (tw *writer) WriteHeader(status int) {
 			pageURL = respURI.String()
 		}
 		header.Set("X-Page-URL", hexEscapeNonASCII(pageURL))
-		header.Set("Vary", "Accept")
+		header.Add("Vary", "Accept")
 		if tw.replaceURLState {
 			header.Set("X-Response-History", "replace")
 		}


### PR DESCRIPTION
Fix issue with the assignment of the Vary header and improve test coverage for
user defined headers.

### Bugfix

- Do not clobber user defined _Vary_ header values when responding from a dual fragment/page endpoint
